### PR TITLE
Fix route path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Baruch Club API Gateway
+
+This project provides a simple Spring Cloud Gateway configuration for routing requests to microservices. It registers with a Eureka server and exposes routes for student, club and event services.
+
+## Building
+
+Use the Maven wrapper to build the project:
+
+```bash
+./mvnw package
+```
+
+## Running
+
+Run the application with:
+
+```bash
+./mvnw spring-boot:run
+```
+
+The gateway starts on port `8765` and requires a running Eureka server at `http://localhost:8761/eureka`.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,4 +22,4 @@ spring.cloud.gateway.routes[1].predicates[0]=Path=/api/clubs/**
 
 spring.cloud.gateway.routes[2].id=event-service
 spring.cloud.gateway.routes[2].uri=lb://event-service
-spring.cloud.gateway.routes[2].predicates[0]=Path=/api/events/** 
+spring.cloud.gateway.routes[2].predicates[0]=Path=/api/events/**


### PR DESCRIPTION
## Summary
- fix trailing space in event service route
- add basic README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ab2b97294832181bee0597ebd724b